### PR TITLE
Change Home page

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -56,7 +56,6 @@ main {
   font-weight: 500;
   font-size: 16px;
   max-height: 50px;
-  min-height: 50px;
   text-align: center;
   line-height: 19px;
   margin: 0 0 5px;
@@ -68,7 +67,7 @@ main {
 }
 
 .main-product .content-product .content-product-details .price {
-  color: $yellow-darker;
+  color: $red;
   font-weight: 700;
   margin-right: 1rem;
   vertical-align: middle;
@@ -93,6 +92,10 @@ main {
 .home {
   hr {
     margin: 0;
+  }
+
+  .nav {
+    margin-top: 20px;
   }
 }
 

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,9 +1,6 @@
 class StaticPagesController < ApplicationController
   def home
-    @trending_pagy, @trending_products = pagy(Product.trending,
-                                              items: Settings.item.max_item_10)
-
-    @new_pagy, @new_products = pagy(Product.newest,
-                                    items: Settings.item.max_item_10)
+    @type = params[:type]&.to_sym || :newest
+    @pagy, @products = pagy Product.try(@type)
   end
 end

--- a/app/views/products/_product.html.erb
+++ b/app/views/products/_product.html.erb
@@ -1,5 +1,5 @@
 <li class="main-product" id="product-<%= product.id %>">
-  <div class="img-product">
+  <div class="img-product thumbnail">
     <%= image_tag product.image, alt: product.name, class: "img-prd" %>
   </div>
   <div class="content-product">
@@ -10,9 +10,9 @@
       <div class="price">
         <span class="money"><%= number_to_currency(product.price) %></span>
       </div>
-      <button type="button" class="btn btn-cart">
-        <%= t ".add_product" %>
-      </button>
+      <h4>
+        <%= "#{t("products.show.sold")} #{product.sold_count}" %>
+      </h4>
     </div>
   </div>
 </li>

--- a/app/views/shared/_product_feed.html.erb
+++ b/app/views/shared/_product_feed.html.erb
@@ -1,9 +1,8 @@
 <section class="wrapper">
-  <h3><%= header %></h3>
   <div class="products">
     <ul>
-      <%= render products %>
+      <%= render @products %>
     </ul>
-    <%== pagy_bootstrap_nav(pagy) %>
+    <%== pagy_bootstrap_nav @pagy %>
   </div>
 </section>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -1,9 +1,11 @@
-<% provide :title, t("base_title") %>
-
 <div class="home">
-  <%= render "shared/product_feed", products: @trending_products,
-             pagy: @trending_pagy, header: t(".trending") %>
-  <hr>
-  <%= render "shared/product_feed", products: @new_products,
-             pagy: @new_pagy, header: t(".newest") %>
+  <ul class="nav nav-tabs">
+    <li role="presentation" class="<%= "active" if @type == :newest %>">
+      <%= link_to t(".newest"), root_path(type: "newest") %>
+    </li>
+    <li role="presentation" class="<%= "active" if @type == :trending %>">
+      <%= link_to t(".trending"), root_path(type: "trending") %>
+    </li>
+  </ul>
+  <%= render "shared/product_feed" %>
 </div>


### PR DESCRIPTION
## Related Tickets
- [#47398](https://edu-redmine.sun-asterisk.vn/issues/47398)

## WHAT (optional)
- Change home page UI, fix conflict with `pagy`

## HOW
- As default, homepage will display newest product. When user select `trending tab`, trending products will be displayed.

## WHY (optional)
- Because when paginate `trending` and `newest` products on the same page will cause conflict with `pagy`

## Evidence (Screenshot or Video)
![Ảnh chụp Màn hình 2022-03-21 lúc 15 44 07](https://user-images.githubusercontent.com/45824015/159228528-f65dc1fd-665f-47d4-930f-8fddd21921b6.png)

![Ảnh chụp Màn hình 2022-03-21 lúc 15 43 12](https://user-images.githubusercontent.com/45824015/159228408-24ccf72b-7835-46d9-95fb-e82f1ef65b74.png)
